### PR TITLE
Fixed gdk_threads_add_idle() usage

### DIFF
--- a/src/fniface.c
+++ b/src/fniface.c
@@ -200,7 +200,7 @@ void gstm_interface_rowaction()
 }
 
 /* error dialog */
-void gstm_interface_error(const char *msg) {
+gboolean gstm_interface_error(const char *msg) {
 	GtkWidget *errordialog = gtk_message_dialog_new (
 		GTK_WINDOW (maindialog),
 		0,
@@ -220,6 +220,8 @@ void gstm_interface_error(const char *msg) {
 		GtkWidget *w = GTK_WIDGET (gtk_builder_get_object (builder, "tunnellist"));
 		gtk_window_set_focus(GTK_WINDOW(maindialog), w);
 	}
+
+	return FALSE;
 }
 
 void gstm_interface_redirlist_init(GtkTreeView *v) {

--- a/src/fniface.h
+++ b/src/fniface.h
@@ -50,7 +50,7 @@ void gstm_interface_rowactivity();
 void gstm_interface_rowaction();
 void gstm_interface_paint_row(GtkTreeSelection *s, gboolean active);
 void gstm_interface_paint_row_id(int id, gboolean active);
-void gstm_interface_error(const char *msg);
+gboolean gstm_interface_error(const char *msg);
 void gstm_interface_properties(int id);
 void gstm_interface_selectrow_id(int id);
 void gstm_dockletmenu_tunnelitem_new(GtkWidget *menu, const gchar *t_name, intptr_t t_id, gboolean t_active);

--- a/src/fnssht.c
+++ b/src/fnssht.c
@@ -154,15 +154,6 @@ gpointer *gstm_ssht_helperthread(gpointer *args)
 	return NULL;
 }
 
-gboolean gstm_ssht_helperthread_refresh_error (gpointer *data)
-{
-	gchar *str = (gchar *)data;
-	gstm_interface_error (str);
-	free (str);
-
-	return FALSE;
-}
-
 gboolean gstm_ssht_helperthread_refresh_gui (gpointer *data)
 {
 	GtkTreeSelection *s = NULL;

--- a/src/fnssht.h
+++ b/src/fnssht.h
@@ -30,7 +30,6 @@ struct Shelperargs {
 	//char **errmsgs;
 };
 
-gboolean gstm_ssht_helperthread_refresh_error (gpointer *data);
 gboolean gstm_ssht_helperthread_refresh_gui (gpointer *data);
 char **gstm_ssht_addssharg(char **args, const char *str);
 void gstm_ssht_starttunnel(int id);


### PR DESCRIPTION
Changed gstm_interface_error from void() to gboolean(), allowing
it to be explicitly removed from the list of event sources and not be
repeatedly called by returning FALSE.

Closes issue #2: [BUG] Error windows never close reported by kero99.