### PR TITLE
Switch gAskpass to command-line handler

### DIFF
--- a/gAskpass/gaskpass.c
+++ b/gAskpass/gaskpass.c
@@ -24,6 +24,8 @@
 #include "main.h"
 #include "gaskpass.h"
 
+char *curpass = NULL;
+
 GtkWidget *dialog = NULL;
 GtkWidget *entry = NULL;
 
@@ -84,18 +86,45 @@ gaskpass_activate (GApplication *app)
 	}
 	
 	gtk_widget_destroy (dialog);
+
+	g_application_quit (app);
+}
+
+static int
+commandLine (GApplication            *app,
+             GApplicationCommandLine *cmdline)
+{
+	gchar **argv;
+	gint argc;
+	
+	argv = g_application_command_line_get_arguments (cmdline, &argc);
+
+	if ( argc > 1 )
+	{
+		curpass = malloc (strlen(argv[1]) + 1);
+		strcpy (curpass, argv[1]);
+	}
+
+	g_strfreev (argv);
+
+	g_application_activate (app);
+	
+	return 0;
 }
 
 static void
 gaskpass_class_init (gAskpassClass *class)
 {
-  G_APPLICATION_CLASS (class)->activate = gaskpass_activate;
+	G_APPLICATION_CLASS (class)->activate = gaskpass_activate;
 }
 
 gAskpass * gaskpass_new (void)
 {
-  return g_object_new (gaskpass_get_type(),
-                       "application-id", "org.gtk.gaskpass",
-                       "flags", G_APPLICATION_HANDLES_OPEN,
-                       NULL);
+	gAskpass *app = g_object_new (gaskpass_get_type(),
+	                              "application-id", "org.gtk.gaskpass",
+	                              "flags", G_APPLICATION_HANDLES_COMMAND_LINE,
+	                              NULL);
+	g_signal_connect (app, "command-line", G_CALLBACK (commandLine), NULL);
+
+	return app;
 }

--- a/gAskpass/main.c
+++ b/gAskpass/main.c
@@ -30,7 +30,6 @@
 #include "gaskpass.h"
 
 char *gstmpixmaps = NULL;
-char *curpass = NULL;
 
 int main (int argc, char **argv)
 {
@@ -42,12 +41,6 @@ int main (int argc, char **argv)
 #endif
 
 	init_pixmaps ();
-
-	if ( argc > 1 )
-	{
-		curpass = malloc (strlen(argv[1]) + 1);
-		strcpy (curpass, argv[1]);
-	}
 
 	return g_application_run (G_APPLICATION (gaskpass_new ()), argc, argv);
 }

--- a/gAskpass/main.h
+++ b/gAskpass/main.h
@@ -20,7 +20,6 @@
  */
 
 char *gstmpixmaps;
-char *curpass;
 
 void init_pixmaps ();
 GdkPixbuf* create_pixbuf (const gchar *filename);


### PR DESCRIPTION
Removed file-open handler from gAskpass and switched it to the generic
command-line handler. Moved argc/argv handling code out of main() and
in to a dedicated callback function.

This change should address issue #4: gaskpass window not displayed,
reported by hrotkogabor.

Using ssh with password authentication makes me sad. That is a separate
issue, and this change does not address it at all.