### PR TITLE
Add -fno-common to Makefile GCC flags

### DIFF
--- a/gAskpass/Makefile.am
+++ b/gAskpass/Makefile.am
@@ -5,7 +5,7 @@ ui_DATA = gaskpass.ui
 
 
 AM_CFLAGS = \
-	-Wall -g -Og -ggdb \
+	-Wall -g -Og -ggdb -fno-common \
 	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\" \
         -DPACKAGE_SRC_DIR=\""$(abs_srcdir)"\" \
         -DPACKAGE_DATA_DIR=\""$(pkgdatadir)"\" \

--- a/gAskpass/gaskpass.h
+++ b/gAskpass/gaskpass.h
@@ -36,7 +36,7 @@ G_BEGIN_DECLS
 typedef struct _gAskpassClass gAskpassClass;
 typedef struct _gAskpass gAskpass;
 
-GtkBuilder *builder;
+extern GtkBuilder *builder;
 
 struct _gAskpass
 {
@@ -48,7 +48,7 @@ struct _gAskpassClass
 	GtkApplicationClass parent_class;
 };
 
-GtkWidget *dialog;
+extern GtkWidget *dialog;
 
 G_END_DECLS
 

--- a/gAskpass/main.h
+++ b/gAskpass/main.h
@@ -21,9 +21,9 @@
 
 #include "gaskpass.h"
 
-gAskpass *app;
-char *gstmpixmaps;
-char *gstmui;
+extern gAskpass *app;
+extern char *gstmpixmaps;
+extern char *gstmui;
 
 void init_paths ();
 GdkPixbuf* create_pixbuf (const gchar *filename);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,7 +8,7 @@ ui_DATA = gstm.ui
 
 
 AM_CFLAGS = \
-	-Wall -g -Og -ggdb \
+	-Wall -g -Og -ggdb -fno-common \
 	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\" \
 	-DPACKAGE_SRC_DIR=\""$(abs_srcdir)"\" \
 	-DPACKAGE_DATA_DIR=\""$(pkgdatadir)"\" \

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -28,6 +28,13 @@
 #include "fnssht.h"
 #include "support.h"
 
+struct sshtunnel **gSTMtunnels;
+struct portredir *portredirPtr;
+struct sshtunnel stunnel;
+struct sshtunnel *sshtunnelPtr;
+
+int tunnelCount = 0;
+int activeCount = 0;
 gboolean noerrors = FALSE;
 
 void gstm_free1tunnel(struct sshtunnel *tun) {

--- a/src/conffile.h
+++ b/src/conffile.h
@@ -36,7 +36,7 @@ struct portredir {
 	xmlChar *port1;
 	xmlChar *host;
 	xmlChar *port2;
-} *portredirPtr;
+};
 
 //tunnelobject
 struct sshtunnel {
@@ -54,12 +54,16 @@ struct sshtunnel {
 	gboolean active;
 	int sshpid;
 	char *fn;
-} stunnel, *sshtunnelPtr;
+};
 
-struct sshtunnel **gSTMtunnels;
-int tunnelCount;
-int activeCount;
-gboolean noerrors;
+extern struct sshtunnel **gSTMtunnels;
+extern struct portredir *portredirPtr;
+extern struct sshtunnel stunnel;
+extern struct sshtunnel *sshtunnelPtr;
+
+extern int tunnelCount;
+extern int activeCount;
+extern gboolean noerrors;
 
 int gstm_readfiles(char *dir, struct sshtunnel ***tptr);
 int gstm_file2tunnel(char *file, struct sshtunnel *tunnel);

--- a/src/gstm.h
+++ b/src/gstm.h
@@ -50,20 +50,20 @@ struct _Gstm
 
 };
 
-int maindiag_width;
-int maindiag_height;
+extern int maindiag_width;
+extern int maindiag_height;
 
-GtkBuilder *builder;
-GtkWidget *maindialog;
-GtkWidget *aboutdialog;
-GtkWidget *newdialog;
-GtkWidget *tundialog;
-GtkWidget *propertiesdialog;
+extern GtkBuilder *builder;
+extern GtkWidget *maindialog;
+extern GtkWidget *aboutdialog;
+extern GtkWidget *newdialog;
+extern GtkWidget *tundialog;
+extern GtkWidget *propertiesdialog;
 
-GtkWidget *statusbar;
-GtkWidget *tunlist;
+extern GtkWidget *statusbar;
+extern GtkWidget *tunlist;
 
-GtkListStore *tunnellist_store;
+extern GtkListStore *tunnellist_store;
 
 GType gstm_get_type (void) G_GNUC_CONST;
 Gstm *gstm_new (void);

--- a/src/main.h
+++ b/src/main.h
@@ -22,10 +22,10 @@
 #include "conffile.h"
 #include "gstm.h"
 
-Gstm *app;
-char *gstmdir;
-char *gstmpixmaps;
-char *gstmui;
+extern Gstm *app;
+extern char *gstmdir;
+extern char *gstmpixmaps;
+extern char *gstmui;
 
 void signalexit					(int sig_num);
 void init_paths					();

--- a/src/systray.h
+++ b/src/systray.h
@@ -21,7 +21,7 @@
 
 #include <gtk/gtk.h>
 
-GtkStatusIcon *ci;
+extern GtkStatusIcon *ci;
 
 void gstm_docklet_create ();
 void gstm_toggle_mainwindow ();


### PR DESCRIPTION
Added -fno-common to GCC flags in src/Makefile.am and
gAskpass/Makefile.am to match new defaults in GCC 10.

Modified various source files to compile with -fno-common enabled.

Closes #13 