### PR TITLE
Main window handling improvements.

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -63,7 +63,12 @@ void on_maindialog_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
 }
 gboolean maindialog_delete_event_cb (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
-	gstm_terminate();
+	if (gstm_docklet_active())
+	{
+		gstm_toggle_mainwindow();
+	} else {
+		gstm_terminate();
+	}
 	return TRUE;
 }
 void btn_start_clicked_cb (GtkButton *button, gpointer user_data)

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -64,7 +64,7 @@ void on_maindialog_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
 gboolean maindialog_delete_event_cb (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
 	gstm_terminate();
-	return FALSE;
+	return TRUE;
 }
 void btn_start_clicked_cb (GtkButton *button, gpointer user_data)
 {

--- a/src/gstm.c
+++ b/src/gstm.c
@@ -134,7 +134,7 @@ gstm_activate (GApplication *application)
 
 	/*	if there's a notification area AND there are one or more 'autostart'
 	 *	tunnels then maindialog is hidden (ie 'start minimized to tray') */
-	if ((a_cnt == 0) || !(IS_APP_INDICATOR(ci) && APP_INDICATOR_STATUS_ACTIVE == app_indicator_get_status(ci)))
+	if ((a_cnt == 0) || !gstm_docklet_active())
 		gtk_widget_show_all (GTK_WIDGET (maindialog));
 
 	//	load saved window size, if any

--- a/src/systray.c
+++ b/src/systray.c
@@ -32,6 +32,13 @@
 
 //GtkStatusIcon *ci = NULL;
 AppIndicator *ci = NULL;
+bool docklet_connected = FALSE;
+
+static void gstm_docklet_connection_changed_cb(AppIndicator* indicator, gboolean connected,
+                                              gpointer user_data)
+{
+	docklet_connected = connected;
+}
 
 void gstm_docklet_create ()
 {
@@ -40,8 +47,14 @@ void gstm_docklet_create ()
 	ci = app_indicator_new ("gSTM", "gSTM", APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
 	g_assert (IS_APP_INDICATOR (ci));
 	g_assert (G_IS_OBJECT (ci));
+	g_signal_connect(G_OBJECT(ci), APP_INDICATOR_SIGNAL_CONNECTION_CHANGED, G_CALLBACK(gstm_docklet_connection_changed_cb), 0);
 	gstm_docklet_menu_refresh();
 	app_indicator_set_status (ci, APP_INDICATOR_STATUS_ACTIVE);
+}
+
+bool gstm_docklet_active ()
+{
+	return docklet_connected;
 }
 
 void gstm_toggle_mainwindow ()

--- a/src/systray.h
+++ b/src/systray.h
@@ -19,6 +19,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
 #include <gtk/gtk.h>
 #include <libappindicator/app-indicator.h>
 
@@ -29,3 +30,4 @@ void gstm_toggle_mainwindow ();
 void gstm_docklet_activated_cb (GtkWidget *widget, gpointer user_data);
 void gstm_docklet_menu_refresh ();
 GtkMenu* gstm_docklet_menu_regen ();
+bool gstm_docklet_active ();


### PR DESCRIPTION
A bugfix and a feature improvment:

1. Bug: The quit confirmation behavior for closing the main window is wrong. It receives the widget delete event and calls gstm_terminate, which terminates the program directly after a confirmation. However, the function returns FALSE, which tells GTK to get rid of the widget (and in turn, the rest of the app). The proper behavior is to return TRUE so the widget remains alive when the cancel button is hit in the inner confirmation (making the close a noop).
2. Improvement: Track when indicator creation is successful (properly) and when it's active, closing the main window hides it instead. Quitting requires hitting the quit button in the main window or indicator menu.