### PR TITLE
Make single-instance behavior work correctly

### DIFF
--- a/src/gstm.c
+++ b/src/gstm.c
@@ -59,6 +59,8 @@ GtkImage *banner = NULL;
 
 GtkListStore *tunnellist_store = NULL;
 
+static bool initial_activation_done = FALSE;
+
 /* Create a new window loading a file */
 static void
 gstm_new_window (GApplication *app)
@@ -100,6 +102,12 @@ gstm_new_window (GApplication *app)
 static void
 gstm_activate (GApplication *application)
 {
+	if (initial_activation_done) {
+		// Just show the main window
+		gtk_window_present (GTK_WINDOW (maindialog));
+		return;
+	}
+
 	int a_cnt = 0;
 
 	gstm_init ((Gstm *)app);
@@ -145,6 +153,7 @@ gstm_activate (GApplication *application)
 
 	//ready for action
 	gstm_interface_showinfo("gSTM ready for action.");
+	initial_activation_done = TRUE;
 }
 
 static void gstm_init (Gstm *object)


### PR DESCRIPTION
The way GApplication works, whenever an app starts up, it will send the
startup and activate signals and call the associated callbacks for your
app. Later, if the app is unique (which is the default), if you open the
app again, it will send the running instance an activate signal.

They way this works right now with gstm, it will result in the main
instance reinitializing, losing track of any running tunnels, then
generating another main window, duplicating any existing ones.

This makes the activation keep track of whether or not it's the initial
activation, simply presenting the main window if it isn't. I had some
crashes when I tried to move this code to the startup function, so I
figure this is the most straightforward way to handle it.