### PR TITLE
gstm: Move config location

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -388,7 +388,7 @@ int gstm_readfiles(char *dir, struct sshtunnel ***tptr) {
 	listlen = scandir(dir, &entrylist, 0, alphasort);
 
 	if (listlen<0) {
-		fprintf(stderr,"** unable to open gSTM directory (%s)",dir);
+		fprintf(stderr,"** unable to open gSTM directory (%s)\n",dir);
 		free(dir);
 		exit(EXIT_FAILURE);
 

--- a/src/main.h
+++ b/src/main.h
@@ -32,5 +32,8 @@ extern char *gstmui;
 void signalexit					(int sig_num);
 void init_paths					();
 void init_config				();
+bool init_oldConfig				();
+bool check_newConfig			();
+void init_newConfig				();
 void gstm_store_window_size		();
 void gstm_load_window_size		();


### PR DESCRIPTION
Moved gstmdir from ~/.gSTM/ to ~/.config/gSTM; Auto-migrate any tunnels
found.

Removal of legacy location will be up to the user, gSTM will not touch
it after migrating to the new location.

Any existing tunnels will have new filenames when they are migrated, but the contents will be identical.