### PR TITLE
Include stdbool.sh

### DIFF
--- a/src/conffile.h
+++ b/src/conffile.h
@@ -22,6 +22,7 @@
 #ifndef _CONFFILE_H
 #define _CONFFILE_H
 
+#include <stdbool.h>
 #include <gtk/gtk.h>
 #include <libxml/xmlmemory.h>
 #include <libxml/parser.h>


### PR DESCRIPTION
Fixes: error: unknown type name ‘bool’



```
In file included from interface.c:23:
main.h:35:1: error: unknown type name ‘bool’
   35 | bool init_oldConfig                             ();
      | ^~~~
main.h:24:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
   23 | #include "gstm.h"
  +++ |+#include <stdbool.h>
   24 | 
main.h:36:1: error: unknown type name ‘bool’
   36 | bool check_newConfig                    ();
      | ^~~~
main.h:36:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
In file included from main.c:27:
main.h:35:1: error: unknown type name ‘bool’
   35 | bool init_oldConfig                             ();
      | ^~~~
main.h:24:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
   23 | #include "gstm.h"
  +++ |+#include <stdbool.h>
   24 | 
main.h:36:1: error: unknown type name ‘bool’
   36 | bool check_newConfig                    ();
      | ^~~~
main.h:36:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
main.c:140:6: error: conflicting types for ‘init_oldConfig’; have ‘_Bool()’
  140 | bool init_oldConfig()
      |      ^~~~~~~~~~~~~~
main.h:35:6: note: previous declaration of ‘init_oldConfig’ with type ‘int()’
   35 | bool init_oldConfig                             ();
      |      ^~~~~~~~~~~~~~
main.c:163:6: error: conflicting types for ‘check_newConfig’; have ‘_Bool()’
  163 | bool check_newConfig()
      |      ^~~~~~~~~~~~~~~
main.h:36:6: note: previous declaration of ‘check_newConfig’ with type ‘int()’
   36 | bool check_newConfig                    ();
      |      ^~~~~~~~~~~~~~~
make[2]: *** [Makefile:433: interface.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [Makefile:433: main.o] Error 1
In file included from conffile.c:26:
main.h:35:1: error: unknown type name ‘bool’
   35 | bool init_oldConfig                             ();
      | ^~~~
main.h:24:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
   23 | #include "gstm.h"
  +++ |+#include <stdbool.h>
   24 | 
main.h:36:1: error: unknown type name ‘bool’
   36 | bool check_newConfig                    ();
      | ^~~~
main.h:36:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
make[2]: *** [Makefile:433: conffile.o] Error 1
In file included from gstm.c:29:
main.h:35:1: error: unknown type name ‘bool’
   35 | bool init_oldConfig                             ();
      | ^~~~
main.h:24:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
   23 | #include "gstm.h"
  +++ |+#include <stdbool.h>
   24 | 
main.h:36:1: error: unknown type name ‘bool’
   36 | bool check_newConfig                    ();
      | ^~~~
main.h:36:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
make[2]: *** [Makefile:433: gstm.o] Error 1
In file included from callbacks.c:24:
main.h:35:1: error: unknown type name ‘bool’
   35 | bool init_oldConfig                             ();
      | ^~~~
main.h:24:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
   23 | #include "gstm.h"
  +++ |+#include <stdbool.h>
   24 | 
main.h:36:1: error: unknown type name ‘bool’
   36 | bool check_newConfig                    ();
      | ^~~~
main.h:36:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
In file included from support.c:34:
main.h:35:1: error: unknown type name ‘bool’
   35 | bool init_oldConfig                             ();
      | ^~~~
main.h:24:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
   23 | #include "gstm.h"
  +++ |+#include <stdbool.h>
   24 | 
main.h:36:1: error: unknown type name ‘bool’
   36 | bool check_newConfig                    ();
      | ^~~~
main.h:36:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; did you forget to ‘#include <stdbool.h>’?
make[2]: *** [Makefile:433: support.o] Error 1
make[2]: *** [Makefile:433: callbacks.o] Error 1
fnssht.c: In function ‘gstm_ssht_helperthread’:
fnssht.c:131:91: warning: ‘%s’ directive argument is null [-Wformat-truncation=]
  131 |                         snprintf (buf2,i,"Tunnel '%s' stopped.\nUnknown error code: %d\n\n%s%s",gSTMtunnels[harg->tid]->name,rv,buf,buf3);
      |                                                                                           ^~
make[2]: Leaving directory '/home/jv/git/aur/gstm-git/src/gstm/src'
make[1]: *** [Makefile:456: all-recursive] Error 1
make[1]: Leaving directory '/home/jv/git/aur/gstm-git/src/gstm'
make: *** [Makefile:353: all] Error 2
```