### PR TITLE
Fix missing stdbool.h include

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -21,6 +21,7 @@
 
 #include "conffile.h"
 #include "gstm.h"
+#include <stdbool.h>
 
 extern Gstm *app;
 extern char *gstmdir;


### PR DESCRIPTION
This fixes a compilation failure under Arch Linux due to `bool` not being implicitly declared.