### PR TITLE
Fix build break due to macro rename in libayatana-appindicator

### DIFF
--- a/src/systray.c
+++ b/src/systray.c
@@ -25,6 +25,10 @@
 
 #ifdef AYATANA
     #include <libayatana-appindicator/app-indicator.h>
+    // See https://github.com/AyatanaIndicators/libayatana-appindicator/pull/59
+    #ifndef IS_APP_INDICATOR
+        #define IS_APP_INDICATOR APP_IS_INDICATOR
+    #endif
 #else
     #include <libappindicator/app-indicator.h>
 #endif


### PR DESCRIPTION
See https://github.com/AyatanaIndicators/libayatana-appindicator/pull/59 for an explanation. The latest version of the library renames IS_APP_INDICATOR to APP_IS_INDICATOR, leading to a build failure when trying to build against it. This modifies the code to handle either case.